### PR TITLE
feat(ui): Make category action button conditional

### DIFF
--- a/web/src/app/components/CategorySelect.tsx
+++ b/web/src/app/components/CategorySelect.tsx
@@ -210,34 +210,80 @@ export default function CategorySelect({ selectedCat, onSelect }: Props) {
           className="w-full rounded-xl border px-3 py-2 bg-white/60 dark:bg-neutral-800/70 outline-none focus:border-neutral-400 dark:focus:border-neutral-600"
         />
         <div className="flex items-center gap-2 pt-1">
-          <button
-            onClick={createCategory}
-            disabled={isCreating || !name.trim()}
-            className="rounded-xl w-10 h-10 sm:w-auto sm:px-4 sm:py-2 flex items-center justify-center bg-black text-white hover:brightness-110 active:scale-[0.99] disabled:opacity-60"
-          >
-            {isCreating ? (
-              '…'
-            ) : (
-              <>
-                <svg
-                  viewBox="0 0 24 24"
-                  className="w-5 h-5 sm:hidden"
-                  aria-hidden="true"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  fill="none"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <line x1="12" y1="5" x2="12" y2="19" />
-                  <line x1="5" y1="12" x2="19" y2="12" />
-                </svg>
-                <span className="hidden sm:inline">
-                  {t('category_select.add')}
-                </span>
-              </>
-            )}
-          </button>
+          {!name.trim() ? (
+            <button
+              onClick={() => setExpanded(false)}
+              className="rounded-xl w-10 h-10 sm:w-auto sm:px-4 sm:py-2 flex items-center justify-center border bg-white/60 dark:bg-neutral-800/70 hover:bg-neutral-100 dark:hover:bg-neutral-700"
+            >
+              {selectedCat ? (
+                <>
+                  <svg
+                    viewBox="0 0 24 24"
+                    className="w-5 h-5 sm:hidden"
+                    aria-hidden="true"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M20 6L9 17l-5-5" />
+                  </svg>
+                  <span className="hidden sm:inline">
+                    {t('category_select.set')}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <svg
+                    viewBox="0 0 24 24"
+                    className="w-5 h-5 sm:hidden"
+                    aria-hidden="true"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                  <span className="hidden sm:inline">
+                    {t('category_select.cancel')}
+                  </span>
+                </>
+              )}
+            </button>
+          ) : (
+            <button
+              onClick={createCategory}
+              disabled={isCreating}
+              className="rounded-xl w-10 h-10 sm:w-auto sm:px-4 sm:py-2 flex items-center justify-center bg-black text-white hover:brightness-110 active:scale-[0.99] disabled:opacity-60"
+            >
+              {isCreating ? (
+                '…'
+              ) : (
+                <>
+                  <svg
+                    viewBox="0 0 24 24"
+                    className="w-5 h-5 sm:hidden"
+                    aria-hidden="true"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                  <span className="hidden sm:inline">
+                    {t('category_select.add')}
+                  </span>
+                </>
+              )}
+            </button>
+          )}
           {selectedCat && (
             <button
               onClick={deleteSelected}

--- a/web/src/app/locales/de.json
+++ b/web/src/app/locales/de.json
@@ -19,7 +19,9 @@
     "load_error": "Kategorien konnten nicht geladen werden.",
     "create_error": "Kategorie konnte nicht erstellt werden.",
     "delete_error": "Kategorie konnte nicht gelöscht werden.",
-    "open_category": "Kategorie öffnen"
+    "open_category": "Kategorie öffnen",
+    "set": "Festlegen",
+    "cancel": "Abbrechen"
   },
   "item_create": {
     "new_entry": "Neuer Eintrag",

--- a/web/src/app/locales/en.json
+++ b/web/src/app/locales/en.json
@@ -19,7 +19,9 @@
     "load_error": "Could not load categories.",
     "create_error": "Could not create category.",
     "delete_error": "Could not delete category.",
-    "open_category": "Open category"
+    "open_category": "Open category",
+    "set": "Set",
+    "cancel": "Cancel"
   },
   "item_create": {
     "new_entry": "New entry",


### PR DESCRIPTION
As you requested, I made the button in the category selection component context-aware.

- If you are typing a new category name, the button is "Add".
- If the input is empty and a category is selected, the button is "Set".
- If the input is empty and no category is selected, the button is "Cancel".

This change provides a better user experience by showing the most relevant action. I also included new icons and i18n translations for the new button states.